### PR TITLE
Fixed tests when run outside of build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ OUTPUT_PATH = bin/
 SOURCE_PATH = src/
 BIN = bin/mbpfan
 CONF = mbpfan.conf
+CONF_TEST_0 = mbpfan.conf.test0
+CONF_TEST_1 = mbpfan.conf.test1
+CONF_TEST_2 = mbpfan.conf.test2
 DOC = README.md
 MAN = mbpfan.8.gz
 
@@ -42,17 +45,22 @@ tests:
 uninstall:
 	rm /usr/sbin/mbpfan
 	rm /etc/mbpfan.conf
+	rm -rf /etc/mbpfan.d
 	rm /lib/systemd/system/mbpfan.service
 	rm /usr/share/man/man8/mbpfan.8.gz
 	rm -rf /usr/share/doc/mbpfan
 
 install: $(BIN)
 	install -d $(DESTDIR)/usr/sbin
-	install -d $(DESTDIR)/etc
+	install -d $(DESTDIR)/etc/mbpfan.d
 	install -d $(DESTDIR)/lib/systemd/system
 	install -d $(DESTDIR)/usr/share/doc/mbpfan
 	install $(BIN) $(DESTDIR)/usr/sbin
 	install -m644 $(CONF) $(DESTDIR)/etc
+	install -Tm644 $(CONF) $(DESTDIR)/etc/mbpfan.d/$(CONF).sample
+	install -m644 $(CONF_TEST_0) $(DESTDIR)/etc/mbpfan.d
+	install -m644 $(CONF_TEST_1) $(DESTDIR)/etc/mbpfan.d
+	install -m644 $(CONF_TEST_2) $(DESTDIR)/etc/mbpfan.d
 	install -m644 $(DOC) $(DESTDIR)/usr/share/doc/mbpfan
 	install -d $(DESTDIR)/usr/share/man/man8
 	install -m644 $(MAN) $(DESTDIR)/usr/share/man/man8

--- a/src/util.c
+++ b/src/util.c
@@ -4,6 +4,18 @@
 #include <syslog.h>
 
 #include "global.h"
+#include "util.h"
+
+bool is_file_readable(const char *path)
+{
+    FILE *f = fopen(path, "r");
+
+    if (f) {
+        fclose(f);
+    }
+
+    return f != NULL;
+}
 
 void mbp_log(int level, const char *fmt, ...)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,9 @@
 #ifndef _UTIL_H_
 #define _UTIL_H_
 
+#include <stdbool.h>
+
+bool is_file_readable(const char *path);
 void mbp_log(int level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 #endif


### PR DESCRIPTION
Settings tests are failing when run outside of the build directory because the test files cannot be found. Since people can run tests any time after installation, I copied the relevant files used in testing to a new directory `/etc/mbpfan.d` in order to let them run properly. I don't think these particular tests are crucial to have after being initially run when built, but the other tests they run with do have value for a regular install. So rather than having the tests fail and give people worrisome error messages, I thought this would be an easy way to let them run correctly.

The tests will still attempt to open the files in the current directory, but if that fails they will use the new location.