### PR TITLE
added power support arch on YML file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+ - amd64
+ - ppc64le
 dist: xenial
 language: c
 script:


### PR DESCRIPTION
Hi Team,
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build has passed without any failures.please check and close this component.

