### PR TITLE
Add Hack for reading more sensors

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -15,6 +15,7 @@ struct s_sensors {
     char* labelDescription;
 	unsigned int temperature;
     struct s_sensors *next;
+    bool ignore;
 };
 
 struct s_fans {

--- a/src/global.h
+++ b/src/global.h
@@ -11,7 +11,9 @@ extern int verbose;
 struct s_sensors {
     FILE* file;
     char* path;
-    unsigned int temperature;
+    char* label;
+    char* labelDescription;
+	unsigned int temperature;
     struct s_sensors *next;
 };
 

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -498,8 +498,9 @@ void set_fan_speed(t_fans* fan, int speed)
        int res = pwrite(fileno(fan->file), buf, len, /*offset=*/ 0);
        if (res == -1) {
           perror("Could not set fan speed");
+       } else {
+    	   fan->old_speed = speed;
        }
-       fan->old_speed = speed;
     }
 }
 

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -540,10 +540,14 @@ unsigned short get_temp_max(t_sensors* sensors)
     t_sensors* tmp = sensors;
 
     while(tmp != NULL) {
-		if ( temp < tmp->temperature){
-			temp = tmp->temperature;
-			temp = tmp->temperature;
-		}
+    	if (tmp->temperature>150*1000){
+    	    mbp_log(LOG_ERR, "Ignoring Sensor %s, Temperature %.2d not plausible", tmp->label,tmp->temperature);
+    	} else {
+    		if ( temp < tmp->temperature){
+    			temp = tmp->temperature;
+    			temp = tmp->temperature;
+    		}
+    	}
     	    	tmp = tmp->next;
     }
 
@@ -693,8 +697,9 @@ void check_requirements(const char* program_path)
 
 void mbpfan()
 {
-    int old_temp, new_temp, fan_speed, steps;
-    int temp_change;
+    float old_temp, new_temp;
+    int  fan_speed, steps;
+    float temp_change;
 	t_sensors *max_sensor;
 
     sensors = retrieve_sensors();
@@ -769,7 +774,7 @@ recalibrate:
             }
 
             if(verbose) {
-	      mbp_log(LOG_INFO, "Old Temp: %d New Temp: %d (%s) Fan: %s Speed: %d", old_temp, new_temp,max_sensor->label, fan->label, fan_speed );
+	      mbp_log(LOG_INFO, "Old Temp: %.2f New Temp: %.2f (%s) Fan: %s Speed: %d", old_temp, new_temp,max_sensor->label, fan->label, fan_speed );
 	    }
 
 	    set_fan_speed(fan, fan_speed);

--- a/src/mbpfan.h
+++ b/src/mbpfan.h
@@ -61,6 +61,13 @@ void retrieve_settings(const char* settings_path, t_fans *fans);
  */
 t_sensors *retrieve_sensors();
 
+
+/**
+ * Read a Single Sensor
+ */
+void read_sensor(t_sensors *sensor);
+
+
 /**
  * Given a linked list of t_sensors, refresh their detected
  * temperature

--- a/src/mbpfan.h
+++ b/src/mbpfan.h
@@ -105,7 +105,13 @@ void set_fan_minimum_speed(t_fans* fans);
 /**
  *  Return maximum CPU temp in degrees
  */
-unsigned short get_temp(t_sensors* sensors);
+unsigned short get_temp_max(t_sensors* sensors);
+
+
+/**
+ * Get the sensor struct with the max temperature
+ */
+t_sensors* get_max_temp_sensor(t_sensors* sensors);
 
 /**
  * Check if user has proper access and that required

--- a/tests/minunit.c
+++ b/tests/minunit.c
@@ -45,6 +45,7 @@ static const char *test_sensor_paths()
         mu_assert("Sensor does not have a valid path", tmp->path != NULL);
 
         if(tmp->path != NULL) {
+        	// printf("Testing %s %s ==> %d\n",tmp->label,tmp->path,tmp->temperature);
             mu_assert("Sensor does not have valid temperature", tmp->temperature > 0);
         }
 
@@ -112,10 +113,10 @@ static const char *test_get_temp()
 {
     t_sensors* sensors = retrieve_sensors();
     mu_assert("No sensors found", sensors != NULL);
-    unsigned short temp_1 = get_temp(sensors);
+    unsigned short temp_1 = get_temp_max(sensors);
     mu_assert("Invalid Global Temperature Found", temp_1 > 1 && temp_1 < 150);
     stress(2000);
-    unsigned short temp_2 = get_temp(sensors);
+    unsigned short temp_2 = get_temp_max(sensors);
     mu_assert("Invalid Higher temp test (if fan was already spinning high, this is not worrying)", temp_1 < temp_2);
     free_sensors(sensors);
     return 0;


### PR DESCRIPTION
On my iMac late 2011 i replaced the broken HDD with a new SSD (Without Apple Thermal Sensor).
After this I adapted the part of temperature reading to also read all Temperature-Sensors under /sys/devices/platform/applesmc.768 too.
In addition I printed out the Sensor Labels for easier debugging.
