### PR TITLE
Improve comments in the config around {low,high,max}_temp settings

### DIFF
--- a/mbpfan.conf
+++ b/mbpfan.conf
@@ -12,7 +12,9 @@
 #
 #min_fan1_speed = 2000	# put the *lowest* value of "cat /sys/devices/platform/applesmc.768/fan*_min"
 #max_fan1_speed = 6200	# put the *highest* value of "cat /sys/devices/platform/applesmc.768/fan*_max"
-low_temp = 63			# try ranges 55-63, default is 63
-high_temp = 66			# try ranges 58-66, default is 66
-max_temp = 86			# take highest number returned by "cat /sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_max", divide by 1000
+
+# temperature units in celcius
+low_temp = 63			# if temperature is below this, fans will run at minimum speed
+high_temp = 66			# if temperature is above this, fan speed will gradually increase
+max_temp = 86			# if temperature is above this, fans will run at maximum speed
 polling_interval = 1	# default is 1 seconds


### PR DESCRIPTION
Amend the comments in mbpfan.conf around `low_temp`, `high_temp`, and `max_temp` to convey more information about what these settings actually are. The meaning was derived from the comments in this region: https://github.com/linux-on-mac/mbpfan/blob/52d897374d25fc7fc1d34425b93958aa583a0c64/src/mbpfan.c#L57-L59

Fixes: #203
