### PR TITLE
Create dinit service definition, update readme with dinit instructions…

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ execute the following (as root):
     sudo systemctl daemon-reload
     sudo systemctl start mbpfan.service
 
+**dinit**
+A [dinit](https://github.com/davmac314/dinit) service definition is also included. To use it, execute the following:
+    
+    sudo cp mbpfan.dinit /etc/dinit.d/mbpfan
+    sudo dinitctl enable mbpfan
+    sudo dinitctl start mbpfan
+
 ## Usage
 
     Usage: ./mbpfan OPTION(S)

--- a/mbpfan.dinit
+++ b/mbpfan.dinit
@@ -1,0 +1,7 @@
+type      = bgprocess
+command   = /usr/bin/mbpfan
+restart   = true
+logfile   = /var/log/dinit/mbpfan.log
+waits-for = loginready
+pid-file  = /var/run/mbpfan.pid
+


### PR DESCRIPTION
This PR adds instructions for starting `mbpfan` on boot for dinit based systems. 

This service definition was tested on Artix Linux (dinit edition) running on a macbook pro (12,1).