### PR TITLE
Fix PIDFile= reference, restart latency in systemd service

### DIFF
--- a/mbpfan.service
+++ b/mbpfan.service
@@ -7,8 +7,9 @@ After=sysinit.target
 Type=simple
 ExecStart=/usr/sbin/mbpfan -f
 ExecReload=/usr/bin/kill -HUP $MAINPID
-PIDFile=/var/run/mbpfan.pid
+PIDFile=/run/mbpfan.pid
 Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
The run directory has been moved from /var/run to /run in systemd,
which results in the following warning at boot:

```
/usr/lib/systemd/system/mbpfan.service:10: PIDFile= references a path below legacy directory /var/run/, updating /var/run/mbpfan.pid → /run/mbpfan.pid; please update the unit file accordingly.
```

Additionally, the service occasionally fails to start if the service
is started before coretemp devices have finished probing, which results
in the following error. This patch fixes this issue.

```
systemd[1]: Started A fan manager daemon for MacBook Pro.
mbpfan[350]: /usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.
systemd[1]: mbpfan.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: mbpfan.service: Scheduled restart job, restart counter is at 1.
systemd[1]: Stopped A fan manager daemon for MacBook Pro.
systemd[1]: Started A fan manager daemon for MacBook Pro.
mbpfan[369]: /usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.
systemd[1]: mbpfan.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: mbpfan.service: Scheduled restart job, restart counter is at 2.
systemd[1]: Stopped A fan manager daemon for MacBook Pro.
mbpfan[380]: /usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.
systemd[1]: Started A fan manager daemon for MacBook Pro.
systemd[1]: mbpfan.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: mbpfan.service: Scheduled restart job, restart counter is at 3.
mbpfan[393]: /usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.
systemd[1]: Stopped A fan manager daemon for MacBook Pro.
systemd[1]: Started A fan manager daemon for MacBook Pro.
systemd[1]: mbpfan.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: mbpfan.service: Scheduled restart job, restart counter is at 4.
systemd[1]: Stopped A fan manager daemon for MacBook Pro.
systemd[1]: Started A fan manager daemon for MacBook Pro.
mbpfan[416]: /usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.
systemd[1]: mbpfan.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: mbpfan.service: Scheduled restart job, restart counter is at 5.
systemd[1]: Stopped A fan manager daemon for MacBook Pro.
systemd[1]: mbpfan.service: Start request repeated too quickly.
systemd[1]: mbpfan.service: Failed with result 'exit-code'.
systemd[1]: Failed to start A fan manager daemon for MacBook Pro.
```

With these small edits to the systemd service, the PID file now points to a location in the preferred directory, and the service is configured to schedule the next restart 1 second after the previous run, if it fails--this allows any devices to finish probing, and the service starts correctly the second time.