### PR TITLE
Add coretemp as module dependency at startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TESTS_PATH = tests/
 TESTS_BIN = bin/mbpfan-tests
 BIN = bin/mbpfan
 CONF = mbpfan.conf
+DEPEND_MODULE = mbpfan.depend.conf
 DOC = README.md
 MAN = mbpfan.8.gz
 
@@ -52,6 +53,7 @@ tests: all
 uninstall:
 	rm /usr/sbin/mbpfan
 	rm /etc/mbpfan.conf
+	rm /lib/modules-load.d/mbpfan.depend.conf
 	rm /lib/systemd/system/mbpfan.service
 	rm /usr/share/man/man8/mbpfan.8.gz
 	rm -rf /usr/share/doc/mbpfan
@@ -63,6 +65,7 @@ install: all
 	install -d $(DESTDIR)/usr/share/doc/mbpfan
 	install $(BIN) $(DESTDIR)/usr/sbin
 	install -m644 $(CONF) $(DESTDIR)/etc
+	install -m644 $(DEPEND_MODULE) $(DESTDIR)/lib/modules-load.d
 	install -m644 $(DOC) $(DESTDIR)/usr/share/doc/mbpfan
 	install -d $(DESTDIR)/usr/share/man/man8
 	install -m644 $(MAN) $(DESTDIR)/usr/share/man/man8

--- a/mbpfan.depend.conf
+++ b/mbpfan.depend.conf
@@ -1,0 +1,1 @@
+coretemp


### PR DESCRIPTION
`mbpfan` service occasionally fails to start because it runs before `coretemp` is loaded, which output the following message

```/usr/sbin/mbpfan needs coretemp support. Please either load it or build it into the kernel. Exiting.```

The `systemd-modules-load.service` runs before `sysinit.target`, and `mbpfan.service` runs after `sysinit.target`. So putting a file in `/lib/modules-load.d` will make coretemp start before mbpfan.