### PR TITLE
Ensure lib/modules-load.d exists before installing there

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ install: all
 	install -d $(DESTDIR)/etc
 	install -d $(DESTDIR)/lib/systemd/system
 	install -d $(DESTDIR)/usr/share/doc/mbpfan
+	install -d $(DESTDIR)/lib/modules-load.d
 	install $(BIN) $(DESTDIR)/usr/sbin
 	install -m644 $(CONF) $(DESTDIR)/etc
 	install -m644 $(DEPEND_MODULE) $(DESTDIR)/lib/modules-load.d


### PR DESCRIPTION
If `$(DESTDIR)/lib/modules-load.d` does not exist yet, then `mbpfan.depend.conf` gets installed with that file name, instead of to `$(DESTDIR)/lib/modules-load.d/mbpfan.depend.conf`. This patch fixes the problem by ensuring the folder exists first.

Patch from AUR [1], I am the packager there. Followup to [2]. See also [3].

[1] https://aur.archlinux.org/cgit/aur.git/commit/?h=mbpfan-git&id=03288aa0926e980fbd456665047a4bda5fc9c5fd
[2] https://github.com/linux-on-mac/mbpfan/pull/253
[3] https://github.com/linux-on-mac/mbpfan/issues/255