### PR TITLE
src/util.c: Fix build with clang-16

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #define __USE_MISC
+#define _GNU_SOURCE
 #include <syslog.h>
 
 #include "global.h"


### PR DESCRIPTION
When building with clang-16, the following build error is raised.

clang -c -O2 -march=x86-64 -pipe -pipe -frecord-gcc-switches -fno-diagnostics-color -fmessage-length=0  -g  -Wall -Wextra -Wno-unused-function -std=c99 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500 src/util.c -osrc/util.o src/util.c:13:9: error: call to undeclared function 'vsyslog'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        vsyslog(level, fmt, args);
        ^
src/util.c:13:9: note: did you mean 'syslog'?
/usr/include/syslog.h:62:6: note: 'syslog' declared here void syslog (int, const char *, ...);

This is due to vsyslog being available when _GNU_SOURCE or _BSD_SOURCE is defined [1]. This patch does that, thus fixing the error.

[1]: https://linux.die.net/man/3/vsyslog

Bug: https://bugs.gentoo.org/894522