### PR TITLE
Do not call signal-unsafe functions in handler

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,7 @@ Checks: '
     -llvm-*,
     -llvmlibc-*,
     -misc-include-cleaner,
+    -misc-unused-parameters,
     -modernize-macro-to-enum,
     -readability-braces-around-statements,
     -readability-else-after-return,

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BINFLAG = -o
 INCLUDES =
 LIBS = -lm
 LIBPATH =
-CFLAGS += $(COPT) -g $(INCLUDES) -Wall -Wextra -Wno-unused-function -std=c99 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500
+CFLAGS += $(COPT) -g $(INCLUDES) -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -std=c99 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500
 LDFLAGS += $(LIBPATH) -g
 
 OBJS := $(patsubst %.$(C),%.$(OBJ),$(wildcard $(SOURCE_PATH)*.$(C)))

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -16,6 +16,11 @@
 #ifndef _DAEMON_H_
 #define _DAEMON_H_
 
+#include <signal.h>
+
+extern sig_atomic_t do_exit;
+extern sig_atomic_t do_reload;
+
 /**
  * Write the PID of the forked daemon to the
  * .pid file defined in char *program_pid
@@ -49,5 +54,7 @@ void signal_handler(int signal);
  * Daemonizes
  */
 void go_daemon(void (*function)());
+
+void cleanup_and_exit(int exit_code);
 
 #endif

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -42,6 +42,7 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/errno.h>
+#include "daemon.h"
 #include "mbpfan.h"
 #include "global.h"
 #include "settings.h"
@@ -660,6 +661,17 @@ recalibrate:
     sleep(2);
 
     while (1) {
+        if (do_exit) {
+            syslog(LOG_WARNING, "Received SIGTERM, SIGQUIT, or SIGINT signal.");
+            cleanup_and_exit(EXIT_SUCCESS);
+        }
+
+        if (do_reload) {
+            syslog(LOG_WARNING, "Received SIGHUP signal.");
+            retrieve_settings(NULL, fans);
+            do_reload = 0;
+        }
+
         old_temp = new_temp;
         new_temp = get_temp(sensors);
 


### PR DESCRIPTION
Found via clang-tidy.